### PR TITLE
docs: make .env.example the single source of truth

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,39 +1,121 @@
-# Required: target group id (must end with @g.us)
+# WhatsApp Poller environment configuration (single source of truth).
+# Copy this file to .env and replace required placeholder values.
+
+# Required: target WhatsApp group JID.
+# Must end with @g.us.
+# Example: 1234567890-123456789@g.us
 GROUP_ID=1234567890-123456789@g.us
 
-# Required: owner phone (used for manual tie override auth)
+# Required: owner phone or JID used for tie override authorization.
+# Accepts phone-like text or JID; normalized to <local>@c.us internally.
+# Example: 905555555555
 OWNER_PHONE=905555555555
 
-# Required: exactly your five eligible voters (comma-separated)
+# Required: comma-separated allowlist of eligible voters.
+# Accepts phone-like values or JIDs; must be unique after normalization.
 ALLOWED_VOTERS=905551111111,905552222222,905553333333,905554444444,905555555555
 
-# Optional settings
+# Optional: local auth client ID used by whatsapp-web.js.
+# Default: game-scheduler
 CLIENT_ID=game-scheduler
-# Optional: enables /health/live, /health/ready, and /metrics when set
+
+# Optional: HTTP port to enable /health/live, /health/ready, and /metrics.
+# Empty disables the HTTP server. Valid range: 1..65535.
+# Example: 8080
 HEALTH_SERVER_PORT=
+
+# Optional: command prefix used in group chat.
+# Must be non-empty if set.
+# Default: !schedule
 COMMAND_PREFIX=!schedule
+
+# Optional: runtime data directory for session/database files.
+# Relative paths resolve from process working directory.
+# Default: ./data
 DATA_DIR=./data
+
+# Optional: run Chromium in headless mode.
+# Accepted: true/false, 1/0, yes/no, on/off.
+# Default: true
 HEADLESS=true
+
+# Optional: disable Chromium sandbox protections.
+# Accepted: true/false, 1/0, yes/no, on/off.
+# Default: false (recommended)
 ALLOW_INSECURE_CHROMIUM=false
+
+# Optional: poll auto-close timeout in hours.
+# Integer >= 1.
+# Default: 48
 POLL_CLOSE_HOURS=48
-# Startup mode:
-# - interactive (default): prompt for target ISO week at startup (current/future only).
-# - auto: use cron + startup catch-up (legacy behavior).
+
+# Optional startup mode:
+# - interactive: prompt for target ISO week at startup.
+# - auto: use cron scheduling and startup catch-up behavior.
+# Default: interactive
 WEEK_SELECTION_MODE=interactive
-# Optional non-interactive startup week override (requires YYYY-Www format, e.g. 2026-W10)
+
+# Optional explicit startup week (mainly for non-interactive startup).
+# Format: YYYY-Www (example: 2026-W10), must be a valid ISO week.
 TARGET_WEEK=
+
+# Optional cron expression for weekly poll creation (used in auto mode).
+# Default: Monday at 12:00 in TIMEZONE.
 POLL_CRON="0 12 * * 1"
+
+# Optional poll question text.
+# Default includes the configured TIMEZONE.
 POLL_QUESTION="Weekly game night - pick all slots you can join (Europe/Istanbul)"
+
+# Optional quorum threshold for closing poll early.
+# Integer >= 1 and <= number of ALLOWED_VOTERS.
+# Default: 5
 REQUIRED_VOTERS=5
+
+# Optional owner tie-override window after poll close, in hours.
+# Integer >= 1.
+# Default: 6
 TIE_OVERRIDE_HOURS=6
+
+# Optional IANA timezone used for scheduling/display.
+# Example: Europe/Istanbul, America/New_York
+# Default: system timezone, then Europe/Istanbul
 TIMEZONE=Europe/Istanbul
-# Optional custom slot template (set only one):
+
+# Optional inline JSON slot template.
+# Set only one of SLOT_TEMPLATE_JSON or SLOT_TEMPLATE_PATH.
+# Each array item must have: weekday (1-7), hour (0-23), minute (0-59).
+# Example:
 # SLOT_TEMPLATE_JSON='[{"weekday":1,"hour":20,"minute":0},{"weekday":6,"hour":10,"minute":0}]'
 SLOT_TEMPLATE_JSON=
-# SLOT_TEMPLATE_PATH=./config/slot-template.json
+
+# Optional path to JSON slot template file.
+# Relative paths resolve from process working directory.
+# Set only one of SLOT_TEMPLATE_JSON or SLOT_TEMPLATE_PATH.
+# Example: ./config/slot-template.json
 SLOT_TEMPLATE_PATH=
+
+# Optional: redact phone/JID-like values in logs.
+# Accepted: true/false, 1/0, yes/no, on/off.
+# Default: true
 LOG_REDACT_SENSITIVE=true
+
+# Optional: include stack traces in error logs.
+# Accepted: true/false, 1/0, yes/no, on/off.
+# Default: false
 LOG_INCLUDE_STACK=false
+
+# Optional command rate-limit count per sender window.
+# Integer >= 1.
+# Default: 8
 COMMAND_RATE_LIMIT_COUNT=8
+
+# Optional command rate-limit window duration in milliseconds.
+# Integer >= 1000.
+# Default: 60000
 COMMAND_RATE_LIMIT_WINDOW_MS=60000
+
+# Optional maximum accepted command text length.
+# Integer >= 16.
+# Default: 256
 COMMAND_MAX_LENGTH=256

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,7 +45,7 @@ Commit prefixes in PR commits:
 
 - Keep scope focused.
 - Include tests for behavior changes.
-- Update docs when configuration or runtime behavior changes.
+- Update docs when configuration or runtime behavior changes (`.env.example` is the canonical env reference).
 - Do not commit secrets, `.env`, or session/database files.
 
 ## Reporting bugs

--- a/README.md
+++ b/README.md
@@ -209,22 +209,10 @@ Use one of these methods:
 
 ## Configuration
 
-See `.env.example` for the complete list. Most relevant settings:
+`.env.example` is the canonical configuration reference for all runtime environment variables, including defaults, valid values, constraints, and examples.
 
-- `WEEK_SELECTION_MODE` - `interactive` (default) or `auto`
-- `TARGET_WEEK` - optional startup week override in `YYYY-Www` format (mainly for non-interactive startup)
-- `POLL_CRON` - weekly schedule cron (used in `auto` mode)
-- `TIMEZONE` - timezone used for scheduling and display
-- `SLOT_TEMPLATE_JSON` - optional JSON array for custom weekly slots (`weekday`, `hour`, `minute`)
-- `SLOT_TEMPLATE_PATH` - optional path to JSON file with custom weekly slots
-- `POLL_CLOSE_HOURS` - auto-close timeout
-- `REQUIRED_VOTERS` - quorum threshold
-- `ALLOW_INSECURE_CHROMIUM` - disable Chromium sandbox (not recommended)
-- `COMMAND_RATE_LIMIT_COUNT`, `COMMAND_RATE_LIMIT_WINDOW_MS` - anti-flood controls
-- `COMMAND_MAX_LENGTH` - max accepted command payload length
-- `HEALTH_SERVER_PORT` - optional HTTP port for `/health/live`, `/health/ready`, `/metrics`
-
-`SLOT_TEMPLATE_JSON` and `SLOT_TEMPLATE_PATH` are mutually exclusive. If neither is set, the default weekday/weekend template is used.
+- Copy `.env.example` to `.env` and change required values (`GROUP_ID`, `OWNER_PHONE`, `ALLOWED_VOTERS`).
+- Use `npm run doctor` after edits to validate your configuration before startup.
 
 ## Development
 


### PR DESCRIPTION
## Summary
- document every env var in .env.example with defaults, constraints, and examples
- simplify README configuration section to point to .env.example as canonical reference
- note canonical env-doc source in CONTRIBUTING.md

## Validation
- verified .env and .env.example key sets match

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Streamlined configuration documentation for clearer setup guidance by consolidating environment variable references to a centralized reference point, improving onboarding experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->