### PR TITLE
Fix #32: accept allowlisted votes when voter JID is @lid

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1321,10 +1321,6 @@ class GameSchedulerBot {
     }
 
     const parts = body.split(/\s+/).filter(Boolean);
-    if (parts.length === 0) {
-      return;
-    }
-
     if (parts.length > MAX_COMMAND_TOKENS) {
       log('WARN', 'Ignoring command: too many tokens.', {
         tokenCount: parts.length,

--- a/test/unit/index.test.js
+++ b/test/unit/index.test.js
@@ -308,8 +308,8 @@ test('onMessageCreate does not warn for non-command messages with many tokens', 
 
   const originalConsoleLog = console.log;
   const logs = [];
-  console.log = (message) => {
-    logs.push(String(message));
+  console.log = (...args) => {
+    logs.push(args.map((value) => String(value)).join(' '));
   };
 
   try {
@@ -322,7 +322,10 @@ test('onMessageCreate does not warn for non-command messages with many tokens', 
     console.log = originalConsoleLog;
   }
 
-  assert.equal(logs.some((entry) => entry.includes('Ignoring command: too many tokens.')), false);
+  assert.equal(
+    logs.some((entry) => entry.includes('Ignoring command: too many tokens.')),
+    false
+  );
 });
 
 test('sendOutboxPayload times out when sendGroupMessage stalls', async (t) => {


### PR DESCRIPTION
## Summary
- resolve poll voter identity aliases from `@lid` to phone JID via `getContactLidAndPhone` before allowlist checks
- cache resolved aliases and keep allowlist strict by only accepting when the resolved phone JID is already allowlisted
- apply command token/length guardrails only to real commands (messages starting with the configured command prefix)
- add regression tests for both fixes

## Testing
- `npm test -- --test test/unit/index.test.js`
- `npm test -- --test test/integration/bot.integration.test.js`
- `npm run lint`

Closes #32


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced voter alias resolution with @lid-based lookups and caching for more reliable voter identification
  * Vote processing updated to use asynchronous normalization for robust handling of allowlisted voters
  * Improved message handling with early command-prefix validation to avoid processing non-commands

* **Tests**
  * Updated tests for asynchronous vote normalization and contact lookup support
  * Added test ensuring long non-command messages do not trigger warnings
<!-- end of auto-generated comment: release notes by coderabbit.ai -->